### PR TITLE
Sdk21to19

### DIFF
--- a/FtcRobotController/FtcRobotController.iml
+++ b/FtcRobotController/FtcRobotController.iml
@@ -82,8 +82,9 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android 5.0.1 Google APIs (1)" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android 4.4.2 Google APIs" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="android-support-v4" level="project" />
     <orderEntry type="library" exported="" name="ModernRobotics-release-" level="project" />

--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion = 'Google Inc.:Google APIs:21'
+    compileSdkVersion = 'Google Inc.:Google APIs:19'
     buildToolsVersion = '21.1.2'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 19
     }
 }


### PR DESCRIPTION
As per issue Default API version for compiling is set to 21 #1 I created this pull request of my proposed changes. Anyone using the ZTE Speed phones should probably use API 19, and anyone experimenting with non-KitKat phones should be setting the API numbers to their target API.