### PR TITLE
Fixed incorrect compileSdkVersion tag

### DIFF
--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -5,7 +5,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 19
     }
-    compileSdkVersion 'Google Inc.:Google APIs:19'
+    compileSdkVersion 19
     buildToolsVersion '21.1.2'
 }
 


### PR DESCRIPTION
In its current state, the official ftc_app repo will not compile in Android Studio. The reason for this is that the compileSdkVersion in build.gradle is declared incorrectly. This can be fixed by simply switching the compileSdkVersion to 19 which creates the intended behavior.