### PR TITLE
Remove unused dependency android-support-v4.jar

### DIFF
--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -42,7 +42,6 @@ allprojects {
 }
 
 dependencies {
-    compile files('libs/android-support-v4.jar')
     compile(name: 'RobotCore-release', ext: 'aar')
     compile(name: 'Hardware-release', ext: 'aar')
     compile(name: 'FtcCommon-release', ext: 'aar')


### PR DESCRIPTION
It appears this library is unused, and furthermore it is not included in the repository.

@tomeng70, please feel free to tell me if you do or don't want pull requests like this. If pulling to another branch is easier, or anything like that, just let me know.