### PR TITLE
Removes *ASUS_PC_01* from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ Thumbs.db
 .idea
 .gradle
 build/
-
-*ASUS_PC_01*
-


### PR DESCRIPTION
Maybe a dev's machine automatically added that line. Who knows, but it's probably unnecessary.