### PR TITLE
build.gradle should use Android SDK's Support Repo

### DIFF
--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -42,7 +42,8 @@ allprojects {
 }
 
 dependencies {
-    compile files('libs/android-support-v4.jar')
+    // Android Support major version should match compileSdkVersion above.
+    compile "com.android.support:support-v4:19.+"
     compile(name: 'RobotCore-release', ext: 'aar')
     compile(name: 'Hardware-release', ext: 'aar')
     compile(name: 'FtcCommon-release', ext: 'aar')


### PR DESCRIPTION
I have no idea how this line ever worked, but using the new version of Gradle with Android Studio 2, the project doesn't compile. I might be doing something wrong, but I don't have this issue in the `master` branch, only in `beta`. This could be because of the new version of Gradle being used, but I can't find anything online to corroborate that. The change to this line should cause Android Studio to scan the SDK for the Android Support Repository and find the proper support dependency.

I've confirmed this fix works on Linux and Windows.
The version chosen is `19.+`. This should get any minor versions and bug fixes still in the major version.