### PR TITLE
Add call to idle() in ConceptVuforiaNavigation

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/ConceptVuforiaNavigation.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/ConceptVuforiaNavigation.java
@@ -319,6 +319,7 @@ public class ConceptVuforiaNavigation extends LinearOpMode {
                 telemetry.addData("Pos", "Unknown");
             }
             telemetry.update();
+            idle();
         }
     }
 


### PR DESCRIPTION
A call to idle() should be included in every while(opModeIsActive()) loop, after the body of the loop and telemetry.update().