### PR TITLE
Allow asymmetric driving with encoderDrive.

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/PushbotAutoDriveByEncoder_Linear.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/PushbotAutoDriveByEncoder_Linear.java
@@ -159,7 +159,7 @@ public class PushbotAutoDriveByEncoder_Linear extends LinearOpMode {
             // keep looping while we are still active, and there is time left, and both motors are running.
             while (opModeIsActive() &&
                    (runtime.seconds() < timeoutS) &&
-                   (robot.leftMotor.isBusy() && robot.rightMotor.isBusy())) {
+                   (robot.leftMotor.isBusy() || robot.rightMotor.isBusy())) {
 
                 // Display it for the driver.
                 telemetry.addData("Path1",  "Running to %7d :%7d", newLeftTarget,  newRightTarget);


### PR DESCRIPTION
Asymmetric driving (such as point turns) causes one motor to finish and the entire function to stop.
Fixed by replacing an and operator with an or.

Dacio Romero 
Highschool mentor for FTC teams 11617, 11618, and 11729
Programmer for FRC team 1502

EDIT: Changed "swing turns" to "point turns" for clarity.