### PR TITLE
Feature/update build dependencies for gradle 4.0 and Android Studio 3.2

### DIFF
--- a/FtcRobotController/build.release.gradle
+++ b/FtcRobotController/build.release.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile (name:'Inspection-release', ext: 'aar')
-    compile (name:'Blocks-release', ext: 'aar')
-    compile (name:'RobotCore-release', ext: 'aar')
-    compile (name:'Hardware-release', ext: 'aar')
-    compile (name:'FtcCommon-release', ext: 'aar')
-    compile (name:'WirelessP2p-release', ext:'aar')
+    api (name:'Inspection-release', ext: 'aar')
+    api (name:'Blocks-release', ext: 'aar')
+    api (name:'RobotCore-release', ext: 'aar')
+    api (name:'Hardware-release', ext: 'aar')
+    api (name:'FtcCommon-release', ext: 'aar')
+    api (name:'WirelessP2p-release', ext:'aar')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,5 +12,9 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
-
-
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}


### PR DESCRIPTION
This fixes issue #576 and the new AAPT2 dependency (AAPT2 was moved to the Google Maven repository in Android Studio 3.2) ☺