### PR TITLE
Fix aapt2

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DriveMethods
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DriveMethods
@@ -1,0 +1,37 @@
+package org.firstinspires.ftc.teamcode;
+
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+/**
+ * Created by shrey on 2017-11-05.
+ */
+
+public class DriveMethods extends HardwarePushBot{
+
+        public static void driveRight(double speed){
+            rightFrontDrive.setPower(speed);
+            rightBackDrive.setPower(speed);
+        }
+
+        public static void driveLeft(double speed){
+            leftFrontDrive.setPower(speed);
+            leftBackDrive.setPower(speed);
+        }
+
+    /*
+     * This method is used to stop the drive motors in order for the robot to stop when in between
+     * the two thresholds. It's important to do this so the robot will stop, safely
+     */
+        public static void stopRightMotors() { //always zero
+            rightFrontDrive.setPower(0);
+            rightBackDrive.setPower(0);
+        }
+
+        public static void stopLeftMotors(){
+            leftFrontDrive.setPower(0);
+            leftBackDrive.setPower(0);
+        }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HardwarePushBot
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HardwarePushBot
@@ -1,0 +1,65 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+/**
+ * Created by shrey on 2018-09-12.
+ */
+public class HardwarePushBot {
+    /* Public OpMode members. */
+    public static DcMotor  leftFrontDrive   = null;
+    public static DcMotor  rightFrontDrive  = null;
+    public static DcMotor  leftBackDrive    = null;
+    public static DcMotor  rightBackDrive   = null;
+    //public static ColorSensor colorSense    = null;
+    //public static Blinker blink = null;
+
+    /* local OpMode members. */
+    com.qualcomm.robotcore.hardware.HardwareMap hwMap           =  null;
+    private ElapsedTime period  = new ElapsedTime();
+
+    /* Constructor */
+    public HardwarePushBot(){
+
+    }
+
+    /* Initialize standard Hardware interfaces */
+    public void init(com.qualcomm.robotcore.hardware.HardwareMap ahwMap) {
+        // Save reference to Hardware map
+        hwMap = ahwMap;
+
+        // Define and Initialize Motors
+        leftFrontDrive  = hwMap.get(DcMotor.class, "left_front_drive");
+
+        leftFrontDrive.setDirection(DcMotor.Direction.REVERSE); // Set to REVERSE if using AndyMark motors
+        leftFrontDrive.setPower(0);
+
+        rightFrontDrive = hwMap.get(DcMotor.class, "right_front_drive");
+        leftBackDrive   = hwMap.get(DcMotor.class, "left_back_drive");
+        rightBackDrive  = hwMap.get(DcMotor.class, "right_back_drive");
+
+        rightFrontDrive.setDirection(DcMotor.Direction.FORWARD);// Set to FORWARD if using AndyMark motors
+        leftBackDrive.setDirection(DcMotor.Direction.REVERSE); // Set to REVERSE if using AndyMark motors
+        rightBackDrive.setDirection(DcMotor.Direction.FORWARD);// Set to FORWARD if using AndyMark motors
+
+        // Set all motors to zero power
+        leftFrontDrive.setPower(0);
+        rightFrontDrive.setPower(0);
+        leftBackDrive.setPower(0);
+        rightBackDrive.setPower(0);
+        //leftArm.setPower(0);
+
+        // Set all motors to run without encoders.
+        // May want to use RUN_USING_ENCODERS if encoders are installed.
+        leftFrontDrive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+        rightFrontDrive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+        leftBackDrive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+        rightBackDrive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+
+        // Color Sensor initialization
+        //colorSense = hwMap.get(ColorSensor.class, "color_sense");
+        //blink = hwMap.get(Blinker.class, "ledController");
+    }
+ }
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TeleOpDrive
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TeleOpDrive
@@ -1,0 +1,63 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+
+@TeleOp(name = "Tel", group = "Sensor")
+public class TeleOpDrive extends LinearOpMode{
+
+    HardwarePushBot robot = new HardwarePushBot();
+
+
+    @Override
+    public void runOpMode() throws InterruptedException {
+
+        // Intialize the robot's hardware from HardwareMap amd allows you to run all this code within TeleOp
+        robot.init(hardwareMap);
+
+        telemetry.addData("Status", "Initialized");
+        telemetry.addData("Hello Driver", "Press Play Button");
+        telemetry.update();
+
+
+
+        // Wait for the game to start (driver presses PLAY)
+        waitForStart();
+        // run until the end of the match (driver presses STOP)
+        while (opModeIsActive()) {
+
+            // Drive variables
+            double rightPower = -gamepad1.right_stick_y * 0.8;
+            double leftPower = -gamepad1.left_stick_y * 0.8;
+            double reverse_Thres = -0.3;
+            double forward_Thres = 0.3;
+            double drive_Speed = 0.7;
+            double turn_Speed = 0.5;
+
+
+            // Send calculated power to wheels
+            // Drive system
+            if (rightPower < forward_Thres && rightPower > reverse_Thres && leftPower < forward_Thres && leftPower > reverse_Thres) {
+                DriveMethods.stopRightMotors();
+                DriveMethods.stopLeftMotors();
+            } else if (rightPower != 0.0 && leftPower != 0.0) {
+                DriveMethods.driveRight(rightPower * drive_Speed);
+                DriveMethods.driveLeft(leftPower * drive_Speed);
+            } else if (rightPower != 0.0 && leftPower == 0.0) {
+                DriveMethods.driveRight(rightPower * drive_Speed);
+            } else if (leftPower != 0.0 && rightPower == 0.0) {
+                DriveMethods.driveLeft(leftPower * drive_Speed);
+            } else if (rightPower < reverse_Thres && leftPower > forward_Thres) {
+                DriveMethods.driveLeft(leftPower * turn_Speed);
+                DriveMethods.driveRight(rightPower * turn_Speed);
+            } else if (rightPower > forward_Thres && leftPower < reverse_Thres) {
+                DriveMethods.driveLeft(leftPower * turn_Speed);
+                DriveMethods.driveRight(rightPower * turn_Speed);
+            }
+
+        }
+
+
+
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
+    }
+    allprojects {
+        repositories {
+            google() // and here
+            jcenter()
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Oct 16 01:00:28 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Fixes `Could not find com.android.tools.build:aapt2:3.2.0-4818971.` error.  

Taken from [Android Studio 3.2 release notes](https://developer.android.com/studio/releases/):

> Beginning with Android Studio 3.2, the source for AAPT2 (Android Asset Packaging Tool 2) is Google's Maven repository.
To use AAPT2, make sure that you have a google() dependency in your build.gradle file