### PR TITLE
Add emacs autosave files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ build/
 
 *ASUS_PC_01*
 
+# Emacs
+*~


### PR DESCRIPTION
Nice addition for anyone using emacs for quick edits, or using it with eclispe backend bindings, JDEE, or etc. Though, to be fair, anyone using emacs probably knows to add this themselves. Still, it shouldn't cause any problems for teams.


