### PR TITLE
fixes typo in teamwebcamcalibrations.xml

### DIFF
--- a/TeamCode/src/main/res/xml/teamwebcamcalibrations.xml
+++ b/TeamCode/src/main/res/xml/teamwebcamcalibrations.xml
@@ -4,7 +4,7 @@
   Each calibration is for a particular camera (indicated by USB vid & pid pair) and a particular
   capture resolution for the camera. Note: it is very important when capturing images used to calibrate
   a camera that the image acquisition tool can actually control this capture resolution within the camera
-  itself and that you use this setting correctly. Many image acquistion tools do not in fact provide
+  itself and that you use this setting correctly. Many image acquisition tools do not in fact provide
   this level of control.
 
   Beyond simply providing additional, new camera calibrations, calibrations provided herein can


### PR DESCRIPTION
# About this PR
We found a typo in the project file and fixed it. The original sentence was:
```text
Many image acquistion tools do not in fact provide this level of control.
```
The word `acquistion` should be `acquisition`.
```text
Many image acquisition tools do not in fact provide this level of control.
```
Thanks for reading this, and we look forward to your reply.